### PR TITLE
Serwer SMS: set sender from sms `fromNumber` field

### DIFF
--- a/src/files/custom/Espo/Modules/SmsProviders/SerwerSms/SerwerSmsSender.php
+++ b/src/files/custom/Espo/Modules/SmsProviders/SerwerSms/SerwerSmsSender.php
@@ -91,7 +91,11 @@ class SerwerSmsSender implements Sender
 
         $username = $integration->get('serwerSmsUsername');
         $password = $integration->get('serwerSmsPassword');
-        $sender = $integration->get('serwerSmsSender') ?? '';
+
+        $sender =
+            $sms->getFromNumber() ??
+            $integration->get('serwerSmsSender') ?? '';
+
         $test = $integration->get('serwerSmsTest') ?? false;
         $timeout = $this->config->get('serwerSmsTimeout') ?? self::TIMEOUT;
 


### PR DESCRIPTION
This pull request allows different senders for each sms entity, instead of using the integration entity's sender name. This gives more flexibility and control over the sender name for each sms.